### PR TITLE
Fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: ["master", "main"]
 
+permissions:
+  contents: read
+
 jobs:
   format-and-lint:
     name: Check Formatting and Linting

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -1,13 +1,13 @@
 name: Deno Formatting and Linting
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: ["master", "main"]
   pull_request:
     branches: ["master", "main"]
-
-permissions:
-  contents: read
 
 jobs:
   format-and-lint:


### PR DESCRIPTION
Potential fix for [https://github.com/Wissididom/Streamer.Bot-Coder/security/code-scanning/3](https://github.com/Wissididom/Streamer.Bot-Coder/security/code-scanning/3)

In general, the fix is to explicitly declare `permissions` for the workflow or job so that `GITHUB_TOKEN` is restricted to the minimal set required. Since this workflow only checks out code and runs local commands (`deno` and `git diff`), it can operate with read‑only access to repository contents; `contents: read` is sufficient and matches CodeQL’s suggested minimal starting point.

The best targeted fix is to add a `permissions` block at the workflow root (top level, alongside `on:` and `jobs:`) so it applies to all jobs in this workflow. Place it between the `on:` block (lines 3–7) and the `jobs:` block (line 9). Use:

```yaml
permissions:
  contents: read
```

No imports or additional methods are needed, as this is just YAML configuration. Existing functionality remains unchanged: the job will still be able to check out code and run `deno` formatting/linting, while `GITHUB_TOKEN` is constrained to read‑only repository contents.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
